### PR TITLE
Ajuste no período de mandato

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,10 +184,9 @@ titulares e 1 (um) suplente, eleitos individualmente pela Assembléia Geral,
 sendo composto obrigatoriamente por Associados Plenos ou Efetivos, conforme
 disposição abaixo, Capítulo VIII, "Das eleições".
 
- § primeiro: o mandato dos membros do Conselho Deliberativo será de 2 (dois)
- anos prorrogados automaticamente até o registro da ata empossando os
- conselheiros eleitos em assembléia; exceto no primeiro exercício, conforme
- disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
+ § primeiro: o mandato dos membros do Conselho Deliberativo será de 2 (dois) anos,
+ iniciando no dia primeiro de janeiro do ano seguinte a data da assembleia; exceto
+ no primeiro exercício, conforme disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
 
  § segundo: o Conselho Deliberativo elegerá, dentre os seus membros, na
  primeira reunião que realizar após cada renovação de seus membros, um
@@ -231,10 +230,9 @@ Capítulo V - Da Diretoria
 -------------------------
 
 Art. 16º - A Diretoria é composta por 4 (quatro) Associados Plenos ou Efetivos
-eleitos pela Assembléia Geral para um mandato de 2 (dois) anos prorrogados
-automaticamente até o registro da ata empossando os novos diretores eleitos em
-assembléia; exceto no primeiro exercício, conforme disposto no Capítulo IX,
-"Das Disposições Gerais e Transitórias".
+eleitos pela Assembléia Geral para um mandato de 2 (dois) anos, iniciando no dia
+primeiro de janeiro do ano seguinte a data da assembleia; exceto no primeiro exercício,
+conforme disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
 
 Art. 17º - Compete à Diretoria planejar e realizar as atividades de entidade de
 acordo com seus objetivos e programas, além do cumprimento das

--- a/README.rst
+++ b/README.rst
@@ -185,8 +185,8 @@ sendo composto obrigatoriamente por Associados Plenos ou Efetivos, conforme
 disposição abaixo, Capítulo VIII, "Das eleições".
 
  § primeiro: o mandato dos membros do Conselho Deliberativo será de 2 (dois) anos,
- iniciando no dia primeiro de janeiro do ano seguinte a data da eleição; exceto
- no primeiro exercício, conforme disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
+ iniciando no dia quinze de janeiro do ano seguinte a data da eleição, e finalizando
+ dois anos após o início do mandato, em quatorze de janeiro.
 
  § segundo: o Conselho Deliberativo elegerá, dentre os seus membros, na
  primeira reunião que realizar após cada renovação de seus membros, um
@@ -231,8 +231,8 @@ Capítulo V - Da Diretoria
 
 Art. 16º - A Diretoria é composta por 4 (quatro) Associados Plenos ou Efetivos
 eleitos pela Assembléia Geral para um mandato de 2 (dois) anos, iniciando no dia
-primeiro de janeiro do ano seguinte a data da eleição; exceto no primeiro exercício,
-conforme disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
+quinze de janeiro do ano seguinte a data da eleição, e finalizando dois anos após
+o início do mandato, em quatorze de janeiro.
 
 Art. 17º - Compete à Diretoria planejar e realizar as atividades de entidade de
 acordo com seus objetivos e programas, além do cumprimento das

--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,7 @@ sendo composto obrigatoriamente por Associados Plenos ou Efetivos, conforme
 disposição abaixo, Capítulo VIII, "Das eleições".
 
  § primeiro: o mandato dos membros do Conselho Deliberativo será de 2 (dois) anos,
- iniciando no dia primeiro de janeiro do ano seguinte a data da assembleia; exceto
+ iniciando no dia primeiro de janeiro do ano seguinte a data da eleição; exceto
  no primeiro exercício, conforme disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
 
  § segundo: o Conselho Deliberativo elegerá, dentre os seus membros, na
@@ -231,7 +231,7 @@ Capítulo V - Da Diretoria
 
 Art. 16º - A Diretoria é composta por 4 (quatro) Associados Plenos ou Efetivos
 eleitos pela Assembléia Geral para um mandato de 2 (dois) anos, iniciando no dia
-primeiro de janeiro do ano seguinte a data da assembleia; exceto no primeiro exercício,
+primeiro de janeiro do ano seguinte a data da eleição; exceto no primeiro exercício,
 conforme disposto no Capítulo IX, "Das Disposições Gerais e Transitórias".
 
 Art. 17º - Compete à Diretoria planejar e realizar as atividades de entidade de


### PR DESCRIPTION
**Qual o problema?**
Hoje são definidos dois anos de mandato para diretoria, fazendo com que os diretores percam acessos as contas bancárias e poderes jurídicos sob a associação, quando a assembleia é agendada com uma data superior a dois anos do início do mandato.

**Solução**
A ideia proposta é alterar o modelo para ficar próximo do esquema eleitoral do TSE, onde a votação é feita em uma data, porém a posse será no dia primeiro de janeiro do ano seguinte. Dessa forma, a validade da chapa e conselhos ficará até o dia 31 de dezembro do segundo ano de mandato.

Isso irá evitar perca de acessos em momentos críticos como as vésperas da Conferência Python Brasil, onde se tem um volume alto de pagamentos a serem feitos a fornecedores.